### PR TITLE
Fixing issues with READ.ME, Adding features to name files after the test, adding support for other test runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 /node_modules

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ module.exports = {
 }
 ```
 
+If you are using Mocha test runner, you can use;
+```js
+  beforeEach(function(browser, done) {
+    require('nightwatch-record').start(browser);
+    done();
+  });
+
+  afterEach(function (browser, done) {
+    const testPassed = this.currentTest.state !== 'failed'; // Fix videoSettings.deleteOnSuccess: true issue with other test runners
+    require('nightwatch-record').stop(browser, done, testPassed);
+  });
+```
+
 
 Enable the video screen recording in your test settings:
 ```json
@@ -30,7 +43,8 @@ Enable the video screen recording in your test settings:
   "test_settings": {
     "default": {
       "videos": {
-      "filename": "example" (required field),
+        "fileName": "example", // Required field
+        "nameAfterTest": true,
         "format": "mp4",
         "enabled": true,
         "deleteOnSuccess": false,
@@ -44,6 +58,12 @@ Enable the video screen recording in your test settings:
   }
 }
 ```
+
+If your configuration is sending `browser.currentTest.results` as `undefined, `videoSettings.deleteOnSuccess: true` will not work properly. This object is currently only supported in Nightwatch test runner (https://github.com/nightwatchjs/nightwatch/issues/1104).
+                      
+Please note that testPassed argument has to be boolean. True in case test passed, false if test failed. 
+
+You can send same argument with other test runners as well, if you can gain this variable in the afterEach hook.
 
 ## License
 Released under the [MIT license](https://opensource.org/licenses/MIT).

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const config = require('./config');
 function mkdirp(dir, mode) {
     const path = require('path');
     const fs = require('fs');
-  
+
     dir = path.resolve(dir);
     if (fs.existsSync(dir)) return dir;
     try {
@@ -20,12 +20,15 @@ function mkdirp(dir, mode) {
     }
 }
 
+let videoSettings;
+let file;
+let format;
+
 module.exports = {
     start: function(browser) {
 
         let def = {};
-        const videoSettings = browser.globals.test_settings.videos;
-        const currentTest = browser.currentTest;
+        videoSettings = browser.globals.test_settings.videos;
 
         if (videoSettings && videoSettings.enabled) {
 
@@ -37,8 +40,8 @@ module.exports = {
             if (isLin) def = config['lin'];
             if (isMac) def = config['mac'];
 
-            const format = videoSettings.format || 'mp4';
-            const file = path.resolve(path.join(videoSettings.path || '', videoSettings.fileName.concat('.', format)));
+            format = videoSettings.format || 'mp4';
+            file = path.resolve(path.join(videoSettings.path || '', videoSettings.fileName.concat('.', format)));
             mkdirp(path.dirname(file));
 
             browser.ffmpeg = require('child_process').execFile('ffmpeg',
@@ -57,24 +60,48 @@ module.exports = {
                     'error',
                     file
                 ],
-          function(error, stdout, stderr) {
-              browser.ffmpeg = null;
-              if (error) {
-                  throw error;
-              }
-          })
-          .on('close', function() {
-
-              if (videoSettings.deleteOnSuccess && !currentTest.results.failed) {
-                  require('fs').unlink(file);
-              }
-          });
+                function(error, stdout, stderr) {
+                    browser.ffmpeg = null;
+                    if (error) {
+                        throw error;
+                    }
+                });
         }
     },
-    stop: function(browser) {
+    stop: function(browser, done, testPassed) {
+        const testResults = browser.currentTest.results;
+
         if (browser.ffmpeg) {
             browser.ffmpeg.stdin.setEncoding('utf8');
             browser.ffmpeg.stdin.write('q');
         }
+
+        if (videoSettings.deleteOnSuccess && typeof testResults === 'undefined' && typeof testPassed !== 'boolean') {
+            console.log(`
+                      Your configuration is sending browser.currentTest.results as undefined, therefore deleteOnSuccess is not working properly.
+                      This object is currently only supported in Nightwatch test runner (https://github.com/nightwatchjs/nightwatch/issues/1104). \n
+                      If you are using Mocha test runner, you can enable videoSettings.deleteOnSuccess: true with;\n
+                      afterEach(function (browser, done) {
+                        const testResults = this.currentTest.state !== 'failed';
+                        require('nightwatch-record').stop(browser, done, testResults);
+                      });
+                      
+                      Please note that testPassed argument has to be boolean. True in case test passed, false if test failed. 
+                      You can send same argument with other test runners as well, if you can gain this variable in the afterEach hook.
+           `);
+
+        }
+
+        const didTestPass = (typeof testResults !== 'undefined' && !testResults.failed) || testPassed;
+
+        if (videoSettings.deleteOnSuccess && didTestPass) {
+            require('fs').unlink(file);
+        } else if (videoSettings.nameAfterTest) {
+            const testName = browser.currentTest.name.replace(/[^\w]/gi, '_');
+            const fileNamedAfterTest = path.resolve(path.join(videoSettings.path || '', testName.concat('.', format)));
+            require('fs').rename(file, fileNamedAfterTest);
+        }
+
+        done();
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightwatch-record",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Nightwatch.js video screen recording via ffmpeg",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Hi,

I noticed that there was issue with fileName in the readme (did not match what index.js was expecting filename vs fileName). This is fixed here.

I added feature nameAfterTest, which makes own unique video for each test run based on their name. Replaces all special characters and whitespaces with _

'Should render website' => Should_render_website.mp4 

Also I had issues with deleteOnSuccess feature as I'm using mocha test runner and not the default nightwatch. 

I forked this, so you can use it with any test runner as long as you can get testPassed variable in afterEach hook and send it down to the recorder.

I made file and videoSetting available for stop and start without declaring them again in the stop function. 

Updated version number to 0.1.0
